### PR TITLE
SNAP-1560 Version 1.2.0 upload

### DIFF
--- a/includes/Admin/GlobalSettings.php
+++ b/includes/Admin/GlobalSettings.php
@@ -90,6 +90,13 @@ class GlobalSettings extends \WC_Settings_Page {
 				'desc' => _x( 'Makes Satoshis/Sats available as currency "SAT" (can be found in WooCommerce->Settings->General)', 'global_settings', 'coinsnap-for-woocommerce' ), // and handles conversion to Bitcoin before creating the invoice on Coinsnap.
 				'id' => 'coinsnap_sats_mode'
 			],
+			'autoredirect' => [
+				'title' => __( 'Redirect after payment', 'coinsnap-for-woocommerce' ),
+				'type' => 'checkbox',
+				'default' => 'yes',
+				'desc' => _x( 'Redirect to Thank You page after payment automatically', 'global_settings', 'coinsnap-for-woocommerce' ),
+				'id' => 'coinsnap_autoredirect'
+			],
 			'debug' => [
 				'title' => __( 'Debug Log', 'coinsnap-for-woocommerce' ),
 				'type' => 'checkbox',

--- a/library/Client/Invoice.php
+++ b/library/Client/Invoice.php
@@ -6,10 +6,50 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+use Coinsnap\WC\Helper\Logger;
 use Coinsnap\Result\InvoicePaymentMethod;
 use Coinsnap\Util\PreciseNumber;
 
 class Invoice extends AbstractClient{
+    
+    public function getCurrencies(): array {
+        if(defined('COINSNAP_CURRENCIES')){
+            return COINSNAP_CURRENCIES;
+        }
+        else {
+            return array("EUR","USD","SATS","BTC","CAD","JPY","GBP","CHF","RUB");
+        }
+    }
+    
+    public function checkPaymentData($amount,$currency): array {
+        
+        $coinsnapCurrencies = $this->getCurrencies();
+        
+        if(defined('COINSNAP_CURRENCIES')){
+            if(!in_array($currency,$coinsnapCurrencies)){
+                return array('result' => false,'error' => 'currencyError','min_value' => '');
+            }
+            elseif($amount === null || $amount === 0){
+                return array('result' => false,'error' => 'amountError','min_value' => 0);
+            }
+            elseif(($currency === "SATS" || $currency === "JPY" || $currency === "RUB") && $amount < 1){
+                return array('result' => false,'error' => 'amountError','min_value' => 1);
+            }
+            elseif($currency === "BTC" && $amount < 0.000001){
+                return array('result' => false,'error' => 'amountError','min_value' => 0.000001);
+            }
+            elseif($amount < 0.01){ 
+                return array('result' => false,'error' => 'amountError','min_value' => 0.01);
+            }
+            else {
+                return array('result' => true);
+            }
+        }
+        else {
+            return array('result' => false,'error' => 'currenciesError','min_value' => '');
+        }
+    }
+    
     public function createInvoice(
         string $storeId,
         string $currency,
@@ -20,15 +60,16 @@ class Invoice extends AbstractClient{
         ?string $redirectUrl = null,
         ?string $referralCode = null,
         ?array $metaData = null,
-        ?InvoiceCheckoutOptions $checkoutOptions = null): \Coinsnap\Result\Invoice {
+        ?bool $redirectAutomatically = true,
+        ?string $walletMessage = null): \Coinsnap\Result\Invoice {
 
         $url = $this->getApiUrl().''.COINSNAP_SERVER_PATH.'/'.urlencode($storeId).'/invoices';
         $headers = $this->getRequestHeaders();
         $method = 'POST';
 
         // Prepare metadata.
-        if(!isset($metaData['orderNumber']) && !empty($orderId)) $metaData['orderNumber'] = $orderId;
-        if(!isset($metaData['customerName']) && !empty($customerName)) $metaData['customerName'] = $customerName;
+        if(!isset($metaData['orderNumber']) && !empty($orderId)){ $metaData['orderNumber'] = $orderId;}
+        if(!isset($metaData['customerName']) && !empty($customerName)){ $metaData['customerName'] = $customerName;}
 
         $body_array = array(
             'amount' => $amount !== null ? $amount->__toString() : null,
@@ -37,7 +78,9 @@ class Invoice extends AbstractClient{
             'redirectUrl' => $redirectUrl,
             'orderId' => $orderId,
             'metadata' => (count($metaData) > 0)? $metaData : null,
-            'referralCode' => $referralCode
+            'referralCode' => $referralCode,
+            'redirectAutomatically' => $redirectAutomatically,
+            'walletMessage' => $walletMessage
         );
 
         $body = wp_json_encode($body_array,JSON_THROW_ON_ERROR);

--- a/library/Util/PreciseNumber.php
+++ b/library/Util/PreciseNumber.php
@@ -38,4 +38,9 @@ class PreciseNumber {
     {
         return $this->value;
     }
+    
+    public function __toFloat(): float
+    {
+        return (float)$this->value;
+    }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: coinsnap
 Tags: Lightning, SATS, bitcoin, WooCommerce, payment gateway
 Tested up to: 6.7
-Stable tag: 1.1.12
+Stable tag: 1.2.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -276,3 +276,6 @@ If you have any other questions, please use our support area. After you have reg
 = 1.1.12 :: 2025-03-09 =
 * Fixed Wordpress warning about non-used wp_get_attachment_image() method for Coinsnap payment gateway icon in WooCommerce payment settings.
 * Compatibility with WooCommerce 9.7.x. is tested.
+
+= 1.2.0 :: 2025-03-28 =
+* Update: .


### PR DESCRIPTION
New version contains:

- SNAP-1560 Woocommerce plugin: set available currencies and try to prevent payment error caused by unavailable currency
- SNAP-1577 Woocommerce: return amount/currency error if error is found
- SNAP-1673 WooCommerce plugin update - add checkbox "redirect after payment automatically" in plugin settings and actual parameters in invoice request